### PR TITLE
Added german translations

### DIFF
--- a/custom_components/alarms_and_reminders/media_player.py
+++ b/custom_components/alarms_and_reminders/media_player.py
@@ -26,6 +26,7 @@ class MediaHandler:
                 {
                     "entity_id": media_player,
                     "message": message,
+                    # TODO: use default assistant language instead of hardcoding it
                     "language": "en"
                 },
                 blocking=True

--- a/custom_components/alarms_and_reminders/sentences/de/alarms.py
+++ b/custom_components/alarms_and_reminders/sentences/de/alarms.py
@@ -1,0 +1,103 @@
+# custom_components/alarms_and_reminders/sentences/alarm.py
+DEFAULT_SENTENCES = {
+    "language": "de",
+    "intents": {
+        "SetAlarm": {
+            "data": [
+                {
+                    "sentences": [
+                        "Stell[e] Wecker (auf|um|für) {datetime}",
+                        "Weck[e] mich [auf] um {datetime}",
+                        "Stelle (den|einen) Wecker (auf|für) {datetime}",
+                        "wake me up at {datetime}",
+                        "Wecker (auf|um|für) {datetime}"
+                    ]
+                }
+            ]
+        },
+        "StopAlarm": {
+            "data": [
+                {
+                    "sentences": [
+                        "stop[e] [den] Wecken",
+                        "[den] Wecker (aus|ausschalten|beenden|deaktivieren|)",
+                    ]
+                }
+            ]
+        },
+        "SnoozeAlarm": {
+            "data": [
+                {
+                    "sentences": [
+                        "[den] Wecker schlummern]",
+                        "schlummern für {minutes} minuten"
+                        "noch {minutes} minuten"
+                        "(lass|gib) mir noch {minutes} minuten"
+                    ]
+                }
+            ]
+        }
+    },
+    "lists": {
+        "datetime": {
+            "type": "text",
+            "values": [
+                "in {time}",
+                "um {time}",
+                "{time} am {date}",
+                "heute um {time}",
+                "morgen um {time}",
+                "übermorgen {time}",
+                "am {date} um {time}"
+            ]
+        },
+        "time": {
+            "type": "text",
+            "values": [
+                "{hour}:{minute} (morgens|vormittags|am Vormittag)",
+                "{hour}:{minute} (nachmittags|abends|am Nachmittag|am Abend)",
+                "{hour} {minute} (morgens|vormittags|am Vormittag)",
+                "{hour} {minute} (nachmittags|abends|am Nachmittag|am Abend)",
+                "{hour} (morgens|vormittags|am Vormittag)",
+                "{hour} (nachmittags|abends|am Nachmittag|am Abend)"
+            ]
+        },
+        "hour": {
+            "type": "number",
+            "range": [
+                {"from": 1, "to": 12}
+            ]
+        },
+        "minute": {
+            "type": "number",
+            "range": [
+                {"from": 0, "to": 59, "step": 1}
+            ]
+        },
+        "date": {
+            "type": "text",
+            "values": [
+                "Montag",
+                "Dienstag",
+                "Mittwoch",
+                "Donnerstag",
+                "Freitag",
+                "Samstag",
+                "Sonntag",
+                "(nächsten|nächste Woche) Montag",
+                "(nächsten|nächste Woche) Dienstag",
+                "(nächsten|nächste Woche) Mittwoch",
+                "(nächsten|nächste Woche) Donnerstag",
+                "(nächsten|nächste Woche) Freitag",
+                "(nächsten|nächste Woche) Samstag",
+                "(nächsten|nächste Woche) Sonntag",
+            ]
+        },
+        "minutes": {
+            "type": "number",
+            "range": [
+                {"from": 1, "to": 60}
+            ]
+        }
+    }
+}

--- a/custom_components/alarms_and_reminders/sentences/de/reminders.py
+++ b/custom_components/alarms_and_reminders/sentences/de/reminders.py
@@ -1,0 +1,46 @@
+DEFAULT_SENTENCES = {
+    "language": "de",
+    "intents": {
+        "SetReminder": {
+            "data": [
+                {
+                    "sentences": [
+                        "erinnere mich an {task} um {datetime}",
+                        "[neue] Erinnerung an {task} um {datetime}",
+                        "erstelle eine Erinnerung an {task} um {datetime}",
+                    ]
+                }
+            ]
+        },
+        "StopReminder": {
+            "data": [
+                {
+                    "sentences": [
+                        "Erinnerung (stoppen|löschen|beenden|abbrechen|ausschalten)",
+                    ]
+                }
+            ]
+        },
+        "SnoozeReminder": {
+            "data": [
+                {
+                    "sentences": [
+                        "pausiere [die] Erinnerung",
+                        "erinnere mich später [nochmal]",
+                        "pausiere die Erinnerung [für] {minutes} Minuten",
+                        "erinnere mich [nochmal] in {minutes} Minuten",
+                    ]
+                }
+            ]
+        }
+    },
+    "lists": {
+        # ...existing code for task, datetime, time, etc...
+        "minutes": {
+            "type": "number",
+            "range": [
+                {"from": 1, "to": 60}
+            ]
+        }
+    }
+}


### PR DESCRIPTION
Thx for creating this component, it is one if the missing pieces for me to finally tick out Alexa. I added the translations for the intents for German.

Is there some place where we would need to register the additional language or is this picked up automatically?

Also I left a todo for the TTS service, as we probably want it to use the default assistant language and not hardcode english.