### PR TITLE
Fix malformed German sentence

### DIFF
--- a/custom_components/alarms_and_reminders/sentences/de/alarms.py
+++ b/custom_components/alarms_and_reminders/sentences/de/alarms.py
@@ -29,7 +29,7 @@ DEFAULT_SENTENCES = {
             "data": [
                 {
                     "sentences": [
-                        "[den] Wecker schlummern]",
+                        "[den] Wecker schlummern",
                         "schlummern für {minutes} minuten"
                         "noch {minutes} minuten"
                         "(lass|gib) mir noch {minutes} minuten"


### PR DESCRIPTION
Intent processing would fail on `hassil.parse_expression.ParseExpressionError: Error in chunk ParseChunk(text='([den] Wecker schlummern])', start_index=0, end_index=26, parse_type=<ParseType.GROUP: 2>) at None` because of a trailing `]`